### PR TITLE
Fixes issue with symbol vs string overriding default

### DIFF
--- a/lib/rsolr_cdrh/helpers.rb
+++ b/lib/rsolr_cdrh/helpers.rb
@@ -46,6 +46,8 @@ module RSolrCdrh
   end
 
   def self.override_params(existing, requested)
+    existing = self.hash_to_s(existing)
+    requested = self.hash_to_s(requested)
     # if existing, requested share a key, requested will triumph
     return existing.merge(requested)
   end

--- a/lib/rsolr_cdrh/version.rb
+++ b/lib/rsolr_cdrh/version.rb
@@ -1,5 +1,5 @@
 module RSolrCdrh
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 
   def self.version
     VERSION

--- a/spec/rsolr_cdrh_spec.rb
+++ b/spec/rsolr_cdrh_spec.rb
@@ -22,7 +22,7 @@ end
 describe RSolrCdrh do
   describe '#version' do
     it 'returns version' do
-      expect(RSolrCdrh.version).to eq '2.0.0'
+      expect(RSolrCdrh.version).to eq '2.1.0'
     end
   end
 
@@ -139,7 +139,7 @@ describe RSolrCdrh::Query do
       expect(facet_p[:sort]).to eq "date desc"
       expect(facet_p[:start]).to eq 0
       expect(facet_p[:rows]).to eq 0
-      expect(facet_p['facet.sort']).to eq "index"
+      expect(facet_p[:'facet.sort']).to eq "index"
     end
   end
 


### PR DESCRIPTION
Previously if you sent :"facet.limit" it would not override "facet.limit"
so now I am just straight up turning everything into a symbol when
queries / get_facet requests are sent in

This is not strictly backwards compatible, as the altered test indicates
but I'm going to allow it because nobody besides me has done anything on the
2.0.0 rails 5 version and this is barely semantically versioned, anyway
